### PR TITLE
Fix "entire month loaded for September 2024" 

### DIFF
--- a/date-functions/date-functions.spec.ts
+++ b/date-functions/date-functions.spec.ts
@@ -38,5 +38,14 @@ describe('date-functions', () => {
       expect(afterCurrentMonthDay.day).toEqual(8);
       expect(afterCurrentMonthDay.isOutOfMonthDay).toBeTruthy();
     });
+
+
+    it('cannot have more than 6 "out of month" days in the first week', () => {
+      const weeks = getWeeksOfPage({ year: 2024, month: 8 });
+
+      const firstWeek = weeks[0];
+
+      expect(firstWeek.filter(({isOutOfMonthDay}) => isOutOfMonthDay).length).toBeLessThan(7);
+    });
   });
 });

--- a/date-functions/date-functions.ts
+++ b/date-functions/date-functions.ts
@@ -23,11 +23,11 @@ export function getWeeksOfPage({ year, month }: GetDaysForPageParams): Day[][] {
     actualDate: new Date(year, month, day)
   }));
 
-  const arrayOfPreviousMonth = numberOfDaysToDayArray(getDaysInMonth(year, month - 1)).slice(-offset).map(day => ({
+  const arrayOfPreviousMonth = offset > 0 ? numberOfDaysToDayArray(getDaysInMonth(year, month - 1)).slice(-offset).map(day => ({
     isOutOfMonthDay: true,
     day,
     actualDate: new Date(year, month - 1, day)
-  }));
+  })) : [];
 
   const arrayOfNextMonth = numberOfDaysToDayArray(getDaysInMonth(year, month + 1)).map(day => ({
     isOutOfMonthDay: true,


### PR DESCRIPTION
## The bug
When the start of the month happened on the first day of the week (in the US calendar: Sunday) the entire previous month was included at the start of month instead of being omitted completely.

The reason was how I calculated the necessary slice of the previous month: I used `.slice(-offset)` where `offset` was the placement of the first day of the current month. In case this value was `0` then `.slice` returned the entire original array consisting the entire month.

## The solution
My simple solution was to return an empty "previous month" array when the `offset` was `0`. Test was added to cover the bug. 