### PR TITLE
Make layout responsive

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,8 +1,6 @@
-import { SafeAreaView, StyleSheet, Text, ActivityIndicator } from 'react-native';
+import { SafeAreaView, StyleSheet, Text, ActivityIndicator, View } from 'react-native';
 import { Calendar } from './components/calendar/calendar';
 import { useDesignFonts } from './hooks/use-design-fonts';
-
-// TODO: add overmind or use Context API for practice
 
 export default function App() {
   const { areFontsBeingLoaded } = useDesignFonts();
@@ -13,8 +11,10 @@ export default function App() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.header}>Calendar</Text>
-      <Calendar/>
+      <View style={styles.insideContainer}>
+        <Text style={styles.header}>Calendar</Text>
+        <Calendar/>
+      </View>
     </SafeAreaView>
   );
 }
@@ -22,14 +22,15 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#030303',
-    alignItems: 'flex-start',
+    backgroundColor: '#030303'
+  },
+  insideContainer: {
+    width: '100%',
+    flex: 1,
+    gap: 16,
     justifyContent: 'center',
-    // this weird number comes from Figma, where the "Left" value was exactly 23.5px
-    padding: 23.5,
-
-    // the exact value was not available in Figma - normally I would ask the designer about it
-    gap: 15
+    alignItems: 'stretch',
+    padding: 16,
   },
   header: {
     fontSize: 32,

--- a/components/calendar/calendar.tsx
+++ b/components/calendar/calendar.tsx
@@ -22,8 +22,6 @@ const styles = StyleSheet.create({
     display: 'flex',
     gap: 10,
 
-    width: '100%',
-
     borderCurve: 'circular',
     borderRadius: 10,
     borderColor: '#3e3e3e',

--- a/components/calendar/week.tsx
+++ b/components/calendar/week.tsx
@@ -15,6 +15,7 @@ const styles = StyleSheet.create({
   container: {
     display: 'flex',
     flexDirection: 'row',
+    justifyContent: 'space-between',
     gap: 5,
   }
 });


### PR DESCRIPTION
## Goals
With so many different device sizes we cannot rely on fixed and rigid values. This PR would make the UI flexible enough to fit on average and modern large mobile device screens.

Two important changes were made:
- replace `width: '100%'` in `<Calendar />` component with `alignItems: 'stretch'` in its container as `width: '100%'` will fail when a `margin` is applied as well. However my goal only was to stretch `<Calendar />` component to its full width and that could have been done by flex.
- use `space-between` for days in calendar to take up whatever space is given.

### Before
<img width="338" alt="image" src="https://github.com/latobibor/take-home-calendar/assets/12050526/59e1ff9c-b16f-4caf-bffa-97503f194e37">


### After
<img width="338" alt="image" src="https://github.com/latobibor/take-home-calendar/assets/12050526/a17d608d-af64-4ba8-98d3-771174667a1c">
